### PR TITLE
Fix: wrong type not compatible with signature in

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -19,7 +19,7 @@ system:
     // required, this must send a single CAN message with the given arbitration
     // ID (i.e. the CAN message ID) and data. The size will never be more than 8
     // bytes.
-    bool send_can(const uint16_t arbitration_id, const uint8_t* data,
+    bool send_can(const uint32_t arbitration_id, const uint8_t* data,
             const uint8_t size) {
         ...
     }


### PR DESCRIPTION
Fix: wrong type not compatible with signature inisotp-c libs.

Change-Id: Ie5709e5c0b7f25c4a1eab876a695c2d24f7fe936
Signed-off-by: Romain Forlot <romain.forlot@iot.bzh>